### PR TITLE
Added support for the custom logo introduced in WordPress 4.5

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -70,6 +70,16 @@ function spacious_setup() {
    // Supporting title tag via add_theme_support (since WordPress 4.1)
    add_theme_support( 'title-tag' );
 
+   // Adds the support for the Custom Logo introduced in WordPress 4.5
+   add_theme_support( 'custom-logo',
+   		array(
+   			'height' => '100',
+   			'width' => '100',
+   			'flex-width' => true,
+   			'flex-height' => true,
+   		)
+   	);
+
 	// Registering navigation menus.
 	register_nav_menus( array(
 		'primary' 	=> __( 'Primary Menu','spacious' ),

--- a/header.php
+++ b/header.php
@@ -46,10 +46,16 @@ wp_head();
 				<div id="header-text-nav-wrap" class="clearfix">
 					<div id="header-left-section">
 						<?php
-						if( ( spacious_options( 'spacious_show_header_logo_text', 'text_only' ) == 'both' || spacious_options( 'spacious_show_header_logo_text', 'text_only' ) == 'logo_only' ) && spacious_options( 'spacious_header_logo_image', '' ) != '' ) {
+						if( ( spacious_options( 'spacious_show_header_logo_text', 'text_only' ) == 'both' || spacious_options( 'spacious_show_header_logo_text', 'text_only' ) == 'logo_only' ) ) {
 						?>
 							<div id="header-logo-image">
-								<a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><img src="<?php echo spacious_options( 'spacious_header_logo_image', '' ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>"></a>
+								<?php if ( spacious_options('spacious_header_logo_image', '') != '') { ?>
+									<a href="<?php echo esc_url( home_url( '/' ) ); ?>" title="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>" rel="home"><img src="<?php echo spacious_options( 'spacious_header_logo_image', '' ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>"></a>
+								<?php } ?>
+
+								<?php if (function_exists('the_custom_logo') && has_custom_logo( $blog_id = 0 )) {
+									spacious_the_custom_logo();
+								} ?>
 							</div><!-- #header-logo-image -->
 						<?php
 						}

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -89,18 +89,20 @@ function spacious_customize_register($wp_customize) {
       'panel' => 'spacious_header_options'
    ));
 
-   $wp_customize->add_setting($spacious_themename.'[spacious_header_logo_image]', array(
-      'default' => '',
-      'type' => 'option',
-      'capability' => 'edit_theme_options',
-      'sanitize_callback' => 'esc_url_raw'
-   ));
+   	if ( !function_exists('the_custom_logo') || ( spacious_options('spacious_header_logo_image', '') != '' ) ) {
+	   $wp_customize->add_setting($spacious_themename.'[spacious_header_logo_image]', array(
+	    	'default' => '',
+	      	'type' => 'option',
+	      	'capability' => 'edit_theme_options',
+	      	'sanitize_callback' => 'esc_url_raw'
+	   	));
 
-   $wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, $spacious_themename.'[spacious_header_logo_image]', array(
-      'label' => __('Upload logo for your header. Recommended image size is 100 X 100 pixels.', 'spacious'),
-      'section' => 'spacious_header_logo',
-      'setting' => $spacious_themename.'[spacious_header_logo_image]'
-   )));
+   		$wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, $spacious_themename.'[spacious_header_logo_image]', array(
+      		'label' => __('Upload logo for your header. Recommended image size is 100 X 100 pixels.', 'spacious'),
+      		'section' => 'spacious_header_logo',
+      		'setting' => $spacious_themename.'[spacious_header_logo_image]'
+   		)));
+	}
 
    // Header logo and text display type option
    $wp_customize->add_section('spacious_show_option', array(

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -99,6 +99,7 @@ function spacious_customize_register($wp_customize) {
 
    		$wp_customize->add_control(new WP_Customize_Image_Control($wp_customize, $spacious_themename.'[spacious_header_logo_image]', array(
       		'label' => __('Upload logo for your header. Recommended image size is 100 X 100 pixels.', 'spacious'),
+      		'description' => sprintf(__( '%sInfo:%s This option will be removed in upcoming update. Please go to Site Identity section to upload the theme logo.', 'spacious'  ), '<strong>', '</strong>'),
       		'section' => 'spacious_header_logo',
       		'setting' => $spacious_themename.'[spacious_header_logo_image]'
    		)));

--- a/inc/functions.php
+++ b/inc/functions.php
@@ -628,4 +628,16 @@ function spacious_wrapper_end() {
 }
 
 add_theme_support( 'woocommerce' );
+
+// Displays the site logo
+if ( ! function_exists( 'spacious_the_custom_logo' ) ) {
+	/**
+	 * Displays the optional custom logo.
+	 */
+	function spacious_the_custom_logo() {
+		if ( function_exists( 'the_custom_logo' )  && ( spacious_options( 'spacious_header_logo_image','' ) == '') ) {
+			the_custom_logo();
+		}
+	}
+}
 ?>

--- a/readme.txt
+++ b/readme.txt
@@ -47,7 +47,7 @@ and we will include it within the theme from next version update.
 == Changelog ==
 
 = Version TBD =
-* Added the Custom Site Logo feature introduced in WordPress 4.5
+* Feature - Added the Custom Site Logo feature introduced in WordPress 4.5
 
 = Version 1.4.1 - 2016-09-02 =
 * Tweaks - Removed Russian language file as 100% translation now available at wordpress.org

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,10 @@ and we will include it within the theme from next version update.
 /**********************************************************/
 
 == Changelog ==
+
+= Version TBD =
+* Added the Custom Site Logo feature introduced in WordPress 4.5
+
 = Version 1.4.1 - 2016-09-02 =
 * Tweaks - Removed Russian language file as 100% translation now available at wordpress.org
 * Tweaks - Removed French language file as 100% translation now available at wordpress.org

--- a/readme.txt
+++ b/readme.txt
@@ -46,7 +46,7 @@ and we will include it within the theme from next version update.
 
 == Changelog ==
 
-= Version TBD =
+= Version 1.4.2 TBD =
 * Feature - Added the Custom Site Logo feature introduced in WordPress 4.5
 
 = Version 1.4.1 - 2016-09-02 =


### PR DESCRIPTION
WordPress 4.5 added a new theme support feature for using a custom logo which allows a logo to be uploaded and used via the Customizer. Its time for us to implement now :P